### PR TITLE
Pipeline:  designate the subset of final render targets

### DIFF
--- a/ddl/out/haskell/LambdaCube/IR.hs
+++ b/ddl/out/haskell/LambdaCube/IR.hs
@@ -489,6 +489,7 @@ data Pipeline
   , textures :: Vector TextureDescriptor
   , samplers :: Vector SamplerDescriptor
   , targets :: Vector RenderTarget
+  , finalTargets :: Vector RenderTarget
   , programs :: Vector Program
   , slots :: Vector Slot
   , streams :: Vector StreamData


### PR DESCRIPTION
This adds a field to `Pipeline`, to define the subset of render textures that carry the final result of the pipeline.