### PR TITLE
Add support for line and triangle-fan mesh types (DDL only)

### DIFF
--- a/ddl/Definitions.hs
+++ b/ddl/Definitions.hs
@@ -448,7 +448,11 @@ mesh = do
 
   data_ "MeshPrimitive" $ do
     enum_  "P_Points"
+    enum_  "P_LineStrip"
+    enum_  "P_LineLoop"
+    enum_  "P_Lines"
     enum_  "P_TriangleStrip"
+    enum_  "P_TriangleFan"
     enum_  "P_Triangles"
     const_ "P_TriangleStripI" [Array Int32]
     const_ "P_TrianglesI"     [Array Int32]


### PR DESCRIPTION
Helps resolve https://github.com/lambdacube3d/lambdacube-gl/issues/17

I wasn't sure if this should include the generated files; they seem to be up to date, so maybe, so I'll open an additional PR with them ( #10 ).

Tested locally by patching both packages and using line loop mesh type in a program.