### PR TITLE
Add support for line and triangle-fan mesh types (with generated code)

### DIFF
--- a/ddl/Definitions.hs
+++ b/ddl/Definitions.hs
@@ -448,7 +448,11 @@ mesh = do
 
   data_ "MeshPrimitive" $ do
     enum_  "P_Points"
+    enum_  "P_LineStrip"
+    enum_  "P_LineLoop"
+    enum_  "P_Lines"
     enum_  "P_TriangleStrip"
+    enum_  "P_TriangleFan"
     enum_  "P_Triangles"
     const_ "P_TriangleStripI" [Array Int32]
     const_ "P_TrianglesI"     [Array Int32]

--- a/ddl/out/cpp/LambdaCube.Mesh.cpp
+++ b/ddl/out/cpp/LambdaCube.Mesh.cpp
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 #include "LambdaCube.Mesh.hpp"
 template<> json toJSON<std::shared_ptr<MeshAttribute>>(std::shared_ptr<MeshAttribute> &v) {
@@ -141,8 +141,20 @@ template<> json toJSON<std::shared_ptr<MeshPrimitive>>(std::shared_ptr<MeshPrimi
     case ::MeshPrimitive::tag::P_Points:
       obj["tag"] = "P_Points";
       break;
+    case ::MeshPrimitive::tag::P_LineStrip:
+      obj["tag"] = "P_LineStrip";
+      break;
+    case ::MeshPrimitive::tag::P_LineLoop:
+      obj["tag"] = "P_LineLoop";
+      break;
+    case ::MeshPrimitive::tag::P_Lines:
+      obj["tag"] = "P_Lines";
+      break;
     case ::MeshPrimitive::tag::P_TriangleStrip:
       obj["tag"] = "P_TriangleStrip";
+      break;
+    case ::MeshPrimitive::tag::P_TriangleFan:
+      obj["tag"] = "P_TriangleFan";
       break;
     case ::MeshPrimitive::tag::P_Triangles:
       obj["tag"] = "P_Triangles";
@@ -171,8 +183,20 @@ template<> std::shared_ptr<MeshPrimitive> fromJSON<std::shared_ptr<MeshPrimitive
   if (tag == "P_Points") {
     tagType = ::MeshPrimitive::tag::P_Points;
   }
+  else if (tag == "P_LineStrip") {
+    tagType = ::MeshPrimitive::tag::P_LineStrip;
+  }
+  else if (tag == "P_LineLoop") {
+    tagType = ::MeshPrimitive::tag::P_LineLoop;
+  }
+  else if (tag == "P_Lines") {
+    tagType = ::MeshPrimitive::tag::P_Lines;
+  }
   else if (tag == "P_TriangleStrip") {
     tagType = ::MeshPrimitive::tag::P_TriangleStrip;
+  }
+  else if (tag == "P_TriangleFan") {
+    tagType = ::MeshPrimitive::tag::P_TriangleFan;
   }
   else if (tag == "P_Triangles") {
     tagType = ::MeshPrimitive::tag::P_Triangles;

--- a/ddl/out/cpp/LambdaCube.Mesh.hpp
+++ b/ddl/out/cpp/LambdaCube.Mesh.hpp
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 #ifndef HEADER_LambdaCube.Mesh_H
 #define HEADER_LambdaCube.Mesh_H
@@ -72,7 +72,11 @@ class MeshPrimitive {
   public:
     enum class tag { 
       P_Points,
+      P_LineStrip,
+      P_LineLoop,
+      P_Lines,
       P_TriangleStrip,
+      P_TriangleFan,
       P_Triangles,
       P_TriangleStripI,
       P_TrianglesI

--- a/ddl/out/cpp/LambdaCube.Mesh2.hpp
+++ b/ddl/out/cpp/LambdaCube.Mesh2.hpp
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 #ifndef HEADER_LambdaCube.Mesh_H
 #define HEADER_LambdaCube.Mesh_H
@@ -82,7 +82,11 @@ class MeshPrimitive {
 public:
   enum class tag { 
     P_Points,
+    P_LineStrip,
+    P_LineLoop,
+    P_Lines,
     P_TriangleStrip,
+    P_TriangleFan,
     P_Triangles,
     P_TriangleStripI,
     P_TrianglesI

--- a/ddl/out/csharp/LambdaCube.Mesh.cs
+++ b/ddl/out/csharp/LambdaCube.Mesh.cs
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 using System;
 using System.Linq;
@@ -64,7 +64,11 @@ namespace LambdaCube.Mesh {
   public class MeshPrimitive {
       public enum Tag { 
         P_Points,
+        P_LineStrip,
+        P_LineLoop,
+        P_Lines,
         P_TriangleStrip,
+        P_TriangleFan,
         P_Triangles,
         P_TriangleStripI,
         P_TrianglesI
@@ -241,7 +245,11 @@ namespace LambdaCube.Mesh {
           MeshPrimitive.Tag tagType;
           switch (tag) {
             case "P_Points": tagType = MeshPrimitive.Tag.P_Points; break;
+            case "P_LineStrip": tagType = MeshPrimitive.Tag.P_LineStrip; break;
+            case "P_LineLoop": tagType = MeshPrimitive.Tag.P_LineLoop; break;
+            case "P_Lines": tagType = MeshPrimitive.Tag.P_Lines; break;
             case "P_TriangleStrip": tagType = MeshPrimitive.Tag.P_TriangleStrip; break;
+            case "P_TriangleFan": tagType = MeshPrimitive.Tag.P_TriangleFan; break;
             case "P_Triangles": tagType = MeshPrimitive.Tag.P_Triangles; break;
             case "P_TriangleStripI": {
               data.P_TriangleStripI tv = new data.P_TriangleStripI();
@@ -351,8 +359,20 @@ namespace LambdaCube.Mesh {
         case MeshPrimitive.Tag.P_Points:
           obj["tag"] = "P_Points";
           break;
+        case MeshPrimitive.Tag.P_LineStrip:
+          obj["tag"] = "P_LineStrip";
+          break;
+        case MeshPrimitive.Tag.P_LineLoop:
+          obj["tag"] = "P_LineLoop";
+          break;
+        case MeshPrimitive.Tag.P_Lines:
+          obj["tag"] = "P_Lines";
+          break;
         case MeshPrimitive.Tag.P_TriangleStrip:
           obj["tag"] = "P_TriangleStrip";
+          break;
+        case MeshPrimitive.Tag.P_TriangleFan:
+          obj["tag"] = "P_TriangleFan";
           break;
         case MeshPrimitive.Tag.P_Triangles:
           obj["tag"] = "P_Triangles";

--- a/ddl/out/haskell/LambdaCube/Mesh.hs
+++ b/ddl/out/haskell/LambdaCube/Mesh.hs
@@ -1,5 +1,5 @@
 -- generated file, do not modify!
--- 2016-11-11T11:17:03.517567000000Z
+-- 2023-10-27T02:34:24.280572454Z
 
 {-# LANGUAGE OverloadedStrings, RecordWildCards #-}
 module LambdaCube.Mesh where
@@ -30,7 +30,11 @@ data MeshAttribute
 
 data MeshPrimitive
   = P_Points
+  | P_LineStrip
+  | P_LineLoop
+  | P_Lines
   | P_TriangleStrip
+  | P_TriangleFan
   | P_Triangles
   | P_TriangleStripI (Vector Int32)
   | P_TrianglesI (Vector Int32)
@@ -75,7 +79,11 @@ instance FromJSON MeshAttribute where
 instance ToJSON MeshPrimitive where
   toJSON v = case v of
     P_Points -> object [ "tag" .= ("P_Points" :: Text)]
+    P_LineStrip -> object [ "tag" .= ("P_LineStrip" :: Text)]
+    P_LineLoop -> object [ "tag" .= ("P_LineLoop" :: Text)]
+    P_Lines -> object [ "tag" .= ("P_Lines" :: Text)]
     P_TriangleStrip -> object [ "tag" .= ("P_TriangleStrip" :: Text)]
+    P_TriangleFan -> object [ "tag" .= ("P_TriangleFan" :: Text)]
     P_Triangles -> object [ "tag" .= ("P_Triangles" :: Text)]
     P_TriangleStripI arg0 -> object [ "tag" .= ("P_TriangleStripI" :: Text), "arg0" .= arg0]
     P_TrianglesI arg0 -> object [ "tag" .= ("P_TrianglesI" :: Text), "arg0" .= arg0]
@@ -85,7 +93,11 @@ instance FromJSON MeshPrimitive where
     tag <- obj .: "tag"
     case tag :: Text of
       "P_Points" -> pure P_Points
+      "P_LineStrip" -> pure P_LineStrip
+      "P_LineLoop" -> pure P_LineLoop
+      "P_Lines" -> pure P_Lines
       "P_TriangleStrip" -> pure P_TriangleStrip
+      "P_TriangleFan" -> pure P_TriangleFan
       "P_Triangles" -> pure P_Triangles
       "P_TriangleStripI" -> P_TriangleStripI <$> obj .: "arg0"
       "P_TrianglesI" -> P_TrianglesI <$> obj .: "arg0"

--- a/ddl/out/java/LambdaCube/Mesh/JSON.java
+++ b/ddl/out/java/LambdaCube/Mesh/JSON.java
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 package LambdaCube.Mesh;
 
@@ -234,7 +234,11 @@ public class JSON {
         MeshPrimitive.Tag tagType;
         switch (tag) {
           case "P_Points": tagType = MeshPrimitive.Tag.P_Points; break;
+          case "P_LineStrip": tagType = MeshPrimitive.Tag.P_LineStrip; break;
+          case "P_LineLoop": tagType = MeshPrimitive.Tag.P_LineLoop; break;
+          case "P_Lines": tagType = MeshPrimitive.Tag.P_Lines; break;
           case "P_TriangleStrip": tagType = MeshPrimitive.Tag.P_TriangleStrip; break;
+          case "P_TriangleFan": tagType = MeshPrimitive.Tag.P_TriangleFan; break;
           case "P_Triangles": tagType = MeshPrimitive.Tag.P_Triangles; break;
           case "P_TriangleStripI": {
             MeshPrimitive.P_TriangleStripI_ tv = new MeshPrimitive().new P_TriangleStripI_();
@@ -348,8 +352,20 @@ public class JSON {
           case P_Points:
             obj.put("tag", "P_Points");
             break;
+          case P_LineStrip:
+            obj.put("tag", "P_LineStrip");
+            break;
+          case P_LineLoop:
+            obj.put("tag", "P_LineLoop");
+            break;
+          case P_Lines:
+            obj.put("tag", "P_Lines");
+            break;
           case P_TriangleStrip:
             obj.put("tag", "P_TriangleStrip");
+            break;
+          case P_TriangleFan:
+            obj.put("tag", "P_TriangleFan");
             break;
           case P_Triangles:
             obj.put("tag", "P_Triangles");

--- a/ddl/out/java/LambdaCube/Mesh/MeshPrimitive.java
+++ b/ddl/out/java/LambdaCube/Mesh/MeshPrimitive.java
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 package LambdaCube.Mesh;
 
@@ -11,7 +11,11 @@ import RT.*;
 public class MeshPrimitive {
   public enum Tag { 
     P_Points,
+    P_LineStrip,
+    P_LineLoop,
+    P_Lines,
     P_TriangleStrip,
+    P_TriangleFan,
     P_Triangles,
     P_TriangleStripI,
     P_TrianglesI

--- a/ddl/out/purescript/LambdaCube/Mesh.purs
+++ b/ddl/out/purescript/LambdaCube/Mesh.purs
@@ -1,5 +1,5 @@
 -- generated file, do not modify!
--- 2016-11-15T20:33:23.430512000000Z
+-- 2023-10-27T02:34:24.280572454Z
 
 module LambdaCube.Mesh where
 import Prelude
@@ -32,7 +32,11 @@ data MeshAttribute
 
 data MeshPrimitive
   = P_Points
+  | P_LineStrip
+  | P_LineLoop
+  | P_Lines
   | P_TriangleStrip
+  | P_TriangleFan
   | P_Triangles
   | P_TriangleStripI (Array Int32)
   | P_TrianglesI (Array Int32)
@@ -76,7 +80,11 @@ instance decodeJsonMeshAttribute :: DecodeJson MeshAttribute where
 instance encodeJsonMeshPrimitive :: EncodeJson MeshPrimitive where
   encodeJson v = case v of
     P_Points -> "tag" := "P_Points" ~> jsonEmptyObject
+    P_LineStrip -> "tag" := "P_LineStrip" ~> jsonEmptyObject
+    P_LineLoop -> "tag" := "P_LineLoop" ~> jsonEmptyObject
+    P_Lines -> "tag" := "P_Lines" ~> jsonEmptyObject
     P_TriangleStrip -> "tag" := "P_TriangleStrip" ~> jsonEmptyObject
+    P_TriangleFan -> "tag" := "P_TriangleFan" ~> jsonEmptyObject
     P_Triangles -> "tag" := "P_Triangles" ~> jsonEmptyObject
     P_TriangleStripI arg0 -> "tag" := "P_TriangleStripI" ~> "arg0" := arg0 ~> jsonEmptyObject
     P_TrianglesI arg0 -> "tag" := "P_TrianglesI" ~> "arg0" := arg0 ~> jsonEmptyObject
@@ -87,7 +95,11 @@ instance decodeJsonMeshPrimitive :: DecodeJson MeshPrimitive where
     tag <- obj .? "tag"
     case tag of
       "P_Points" -> pure P_Points
+      "P_LineStrip" -> pure P_LineStrip
+      "P_LineLoop" -> pure P_LineLoop
+      "P_Lines" -> pure P_Lines
       "P_TriangleStrip" -> pure P_TriangleStrip
+      "P_TriangleFan" -> pure P_TriangleFan
       "P_Triangles" -> pure P_Triangles
       "P_TriangleStripI" -> P_TriangleStripI <$> obj .? "arg0"
       "P_TrianglesI" -> P_TrianglesI <$> obj .? "arg0"

--- a/ddl/out/swift/LambdaCube.Mesh.swift
+++ b/ddl/out/swift/LambdaCube.Mesh.swift
@@ -1,5 +1,5 @@
 // generated file, do not modify!
-// 2016-11-11T11:17:03.517567000000Z
+// 2023-10-27T02:34:24.280572454Z
 
 enum MeshAttribute {
   case A_Float(Array<Float>)
@@ -15,7 +15,11 @@ enum MeshAttribute {
 
 enum MeshPrimitive {
   case P_Points
+  case P_LineStrip
+  case P_LineLoop
+  case P_Lines
   case P_TriangleStrip
+  case P_TriangleFan
   case P_Triangles
   case P_TriangleStripI(Array<Int32>)
   case P_TrianglesI(Array<Int32>)
@@ -112,8 +116,16 @@ extension MeshPrimitive {
     switch self {
       case .P_Points:
         return [ "tag" : "P_Points"]
+      case .P_LineStrip:
+        return [ "tag" : "P_LineStrip"]
+      case .P_LineLoop:
+        return [ "tag" : "P_LineLoop"]
+      case .P_Lines:
+        return [ "tag" : "P_Lines"]
       case .P_TriangleStrip:
         return [ "tag" : "P_TriangleStrip"]
+      case .P_TriangleFan:
+        return [ "tag" : "P_TriangleFan"]
       case .P_Triangles:
         return [ "tag" : "P_Triangles"]
       case .P_TriangleStripI(let arg0):

--- a/lambdacube-ir.haskell/src-generated/LambdaCube/Mesh.hs
+++ b/lambdacube-ir.haskell/src-generated/LambdaCube/Mesh.hs
@@ -1,5 +1,5 @@
 -- generated file, do not modify!
--- 2016-11-11T11:17:03.517567000000Z
+-- 2023-10-27T02:34:24.280572454Z
 
 {-# LANGUAGE OverloadedStrings, RecordWildCards #-}
 module LambdaCube.Mesh where
@@ -30,7 +30,11 @@ data MeshAttribute
 
 data MeshPrimitive
   = P_Points
+  | P_LineStrip
+  | P_LineLoop
+  | P_Lines
   | P_TriangleStrip
+  | P_TriangleFan
   | P_Triangles
   | P_TriangleStripI (Vector Int32)
   | P_TrianglesI (Vector Int32)
@@ -75,7 +79,11 @@ instance FromJSON MeshAttribute where
 instance ToJSON MeshPrimitive where
   toJSON v = case v of
     P_Points -> object [ "tag" .= ("P_Points" :: Text)]
+    P_LineStrip -> object [ "tag" .= ("P_LineStrip" :: Text)]
+    P_LineLoop -> object [ "tag" .= ("P_LineLoop" :: Text)]
+    P_Lines -> object [ "tag" .= ("P_Lines" :: Text)]
     P_TriangleStrip -> object [ "tag" .= ("P_TriangleStrip" :: Text)]
+    P_TriangleFan -> object [ "tag" .= ("P_TriangleFan" :: Text)]
     P_Triangles -> object [ "tag" .= ("P_Triangles" :: Text)]
     P_TriangleStripI arg0 -> object [ "tag" .= ("P_TriangleStripI" :: Text), "arg0" .= arg0]
     P_TrianglesI arg0 -> object [ "tag" .= ("P_TrianglesI" :: Text), "arg0" .= arg0]
@@ -85,7 +93,11 @@ instance FromJSON MeshPrimitive where
     tag <- obj .: "tag"
     case tag :: Text of
       "P_Points" -> pure P_Points
+      "P_LineStrip" -> pure P_LineStrip
+      "P_LineLoop" -> pure P_LineLoop
+      "P_Lines" -> pure P_Lines
       "P_TriangleStrip" -> pure P_TriangleStrip
+      "P_TriangleFan" -> pure P_TriangleFan
       "P_Triangles" -> pure P_Triangles
       "P_TriangleStripI" -> P_TriangleStripI <$> obj .: "arg0"
       "P_TrianglesI" -> P_TrianglesI <$> obj .: "arg0"


### PR DESCRIPTION
Helps resolve https://github.com/lambdacube3d/lambdacube-gl/issues/17

This includes the generated files; for just the DDL change, there is #9

Tested locally by patching both packages and using line loop mesh type in a program.